### PR TITLE
Replace es6 module import/exports with commonjs require

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,32 +1,32 @@
 module.exports = {
-    'env': {
-        'es2021': true,
-        'node': true,
-        'jest': true
+    "env": {
+        "commonjs": true,
+        "es2021": true,
+        "node": true,
+        "jest": true
     },
-    'plugins': ['jest'],
-    'extends': 'eslint:recommended',
-    'overrides': [],
-    'parserOptions': {
-        'ecmaVersion': 'latest',
-        'sourceType': 'module'
+    "extends": "eslint:recommended",
+    "overrides": [
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest"
     },
-    'rules': {
-        'indent': [
-            'error',
+    "rules": {
+        "indent": [
+            "error",
             2
         ],
-        'linebreak-style': [
-            'error',
-            'unix'
+        "linebreak-style": [
+            "error",
+            "unix"
         ],
-        'quotes': [
-            'error',
-            'single'
+        "quotes": [
+            "error",
+            "single"
         ],
-        'semi': [
-            'error',
-            'always'
+        "semi": [
+            "error",
+            "always"
         ]
     }
-};
+}

--- a/application/decode.js
+++ b/application/decode.js
@@ -1,16 +1,20 @@
-import { getById } from '../data-access/index.js';
+const dataAccess = require('../data-access/index.js');
 
-export default function decoder (encodedUrl) {
-  let protocolIncludedEncodedUrl = encodedUrl;
-  if (!/^https?:\/\//i.test(encodedUrl)) {
-    protocolIncludedEncodedUrl = 'http://' + encodedUrl;
+const application = {
+  decode(encodedUrl) {
+    let protocolIncludedEncodedUrl = encodedUrl;
+    if (!/^https?:\/\//i.test(encodedUrl)) {
+      protocolIncludedEncodedUrl = 'http://' + encodedUrl;
+    }
+    const url = new URL(protocolIncludedEncodedUrl);
+    if (url.host !== 'short.link' && url.host !== 'www.short.link') {
+      const error = new Error('Should provide a short.link URL.');
+      error.code = 400;
+      throw error;
+    }
+    const shortUrlId = url.pathname.replace(/^\/+/g, '');
+    return dataAccess.getById(shortUrlId);
   }
-  const url = new URL(protocolIncludedEncodedUrl);
-  if (url.host !== 'short.link' && url.host !== 'www.short.link') {
-    const error = new Error('Should provide a short.link URL.');
-    error.code = 400;
-    throw error;
-  }
-  const shortUrlId = url.pathname.replace(/^\/+/g, '');
-  return getById(shortUrlId);
-}
+};
+
+module.exports = application;

--- a/application/encode.js
+++ b/application/encode.js
@@ -1,18 +1,29 @@
-import randomstring from 'randomstring';
-import idGenerationConfig from '../config/idGenerationConfig.js';
-import { getById, store } from '../data-access/index.js';
+const randomstring = require('randomstring');
+const idGenerationConfig = require('../config/idGenerationConfig.js');
+const dataAccess = require('../data-access/index.js');
 
-export default function shorten (url) {
-  let id;
-  do {
-    id = randomstring.generate(idGenerationConfig);
-  } while (getById(id));
+const application = {
+  encode (url) {
+    let id;
+    let tryCount = 0;
+    do {
+      id = randomstring.generate(idGenerationConfig);
+      tryCount++;
+      if (tryCount > idGenerationConfig.maxTryCount) {
+        const error = new Error(`Could not generate a short url after ${tryCount} tries`);
+        error.code = 500;
+        throw error;
+      }
+    } while (dataAccess.getById(id));
 
-  const shortenedUrlObject = {
-    id,
-    shortUrl: `http://short.link/${id}`,
-    originalUrl: url,
-    createdAt: Date.now()
-  };
-  return store(shortenedUrlObject);
-}
+    const shortenedUrlObject = {
+      id,
+      shortUrl: `http://short.link/${id}`,
+      originalUrl: url,
+      createdAt: Date.now()
+    };
+    return dataAccess.store(shortenedUrlObject);
+  },
+};
+
+module.exports = application;

--- a/application/tests/encode.test.js
+++ b/application/tests/encode.test.js
@@ -1,0 +1,21 @@
+const db = require('../../data-access/datastore.js');
+const dataaccess = require('../../data-access/index.js');
+const encodeApp = require('../encode.js');
+
+describe('encode', () => {
+  beforeEach(() => {
+    db.flushAll();
+  });
+
+  it('should throw an error when there are too many collisions', async () => {
+    // Creating collision by returning a stored url no matter what the id is.
+    jest.spyOn(dataaccess, 'getById').mockReturnValue({
+      createdAt: Date.now(),
+      id: 'ABCDEF',
+      shortUrl: 'https://short.link/ABCDEF',
+      url: 'https://example.com/',
+    });
+    const sampleUrl = 'https://www.example.com/example';
+    expect(() => encodeApp.encode(sampleUrl)).toThrow(/Could not generate a short url after/);
+  });
+});

--- a/config/idGenerationConfig.js
+++ b/config/idGenerationConfig.js
@@ -2,6 +2,7 @@ const idGenerationConfig = {
   length: process.env.SHORT_URL_LENGTH || 6,
   readable: process.env.READABLE_URLS || true,
   capitalization: process.env.SHORT_URL_CAPITALIZATION || 'uppercase',
+  maxTryCount: process.env.MAX_TRY_COUNT || 50,
 };
 
-export default idGenerationConfig;
+module.exports = idGenerationConfig;

--- a/config/rateLimit.js
+++ b/config/rateLimit.js
@@ -5,4 +5,4 @@ const rateLimitConfig = {
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 };
 
-export default rateLimitConfig;
+module.exports = rateLimitConfig;

--- a/config/server.js
+++ b/config/server.js
@@ -1,1 +1,2 @@
-export const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3000;
+module.exports = port;

--- a/data-access/datastore.js
+++ b/data-access/datastore.js
@@ -1,3 +1,3 @@
-import NodeCache from 'node-cache';
+const NodeCache = require('node-cache');
 
-export default new NodeCache();
+module.exports = new NodeCache();

--- a/data-access/index.js
+++ b/data-access/index.js
@@ -1,10 +1,13 @@
-import db from './datastore.js';
+const db = require('./datastore.js');
 
-export function getById (id) {
-  return db.get(id);
-}
+const dataAccess = {
+  getById(id) {
+    return db.get(id);
+  },
+  store(urlObject) {
+    db.set(urlObject.id, urlObject);
+    return urlObject;
+  },
+};
 
-export function store (urlObject) {
-  db.set(urlObject.id, urlObject);
-  return urlObject;
-}
+module.exports = dataAccess;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import app from './presentation/index.js';
+const app = require('./presentation/index.js');
 
-import {port} from './config/server.js';
+const port = require('./config/server.js');
 
 app.listen(port, () =>
   console.log(`Url shortener running on port: ${port}`)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 /** @type {import('jest').Config} */
-export default {
+const config = {
   verbose: true,
-  testEnvironment: 'jest-environment-node',
-  transform: {}
 };
+
+module.exports = config;

--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -1,7 +1,7 @@
-import rateLimit from 'express-rate-limit';
+const rateLimit = require('express-rate-limit');
 
-import rateLimitConfig from '../config/rateLimit.js';
+const rateLimitConfig = require('../config/rateLimit.js');
 
 const limiter = rateLimit(rateLimitConfig);
 
-export default limiter;
+module.exports = limiter;

--- a/middleware/tests/rateLimiter.test.js
+++ b/middleware/tests/rateLimiter.test.js
@@ -1,9 +1,9 @@
-import request from 'supertest';
+const request = require('supertest');
 
-import rateLimitConfig from '../../config/rateLimit.js';
+const rateLimitConfig = require('../../config/rateLimit.js');
 
-import db from '../../data-access/datastore.js';
-import app from '../../presentation/index.js';
+const db = require('../../data-access/datastore.js');
+const app = require('../../presentation/index.js');
 
 describe('/encode rate limiter', () => {
   beforeEach(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "helmet": "^6.0.1",
         "node-cache": "^5.1.2",
         "randomstring": "^1.2.3",
-        "rate-limiter-flexible": "^2.4.1",
         "validator": "^13.7.0"
       },
       "devDependencies": {
@@ -5509,11 +5508,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/rate-limiter-flexible": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
-      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
-    },
     "node_modules/raw-body": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
@@ -10569,11 +10563,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "rate-limiter-flexible": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz",
-      "integrity": "sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g=="
     },
     "raw-body": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "randomstring": "^1.2.3",
     "validator": "^13.7.0"
   },
-  "type": "module",
   "devDependencies": {
     "eslint": "^8.33.0",
     "eslint-config-standard": "^17.0.0",

--- a/presentation/decode.js
+++ b/presentation/decode.js
@@ -1,49 +1,54 @@
-import validator from 'validator';
-import decoder from '../application/decode.js';
+const validator = require('validator');
 
-export default (req, res) => {
-  try {
-    const {encodedUrl} = req.query;
-    if (!encodedUrl) {
+const decodeApp = require('../application/decode.js');
+
+const presentation = {
+  decode(req, res) {
+    try {
+      const {encodedUrl} = req.query;
+      if (!encodedUrl) {
+        return res
+          .status(400)
+          .json({
+            message: 'Should provide a url to decode'
+          });
+      }
+      if (!validator.isURL(encodedUrl)) {
+        return res
+          .status(400)
+          .json({
+            message: 'Should provide a valid url'
+          });
+      }
+      const storedUrl = decodeApp.decode(encodedUrl);
+      if (!storedUrl) {
+        return res
+          .status(404)
+          .json({
+            message: 'Short url not found.'
+          });
+      }
       return res
-        .status(400)
+        .status(200)
         .json({
-          message: 'Should provide a url to decode'
+          message: 'Success',
+          data: storedUrl
+        });
+    } catch (error) {
+      if (error.code) {
+        return res
+          .status(error.code)
+          .json({
+            message: error.message
+          });
+      }
+      return res
+        .status(500)
+        .json({
+          message: 'Sorry, something on our went wrong.'
         });
     }
-    if (!validator.isURL(encodedUrl)) {
-      return res
-        .status(400)
-        .json({
-          message: 'Should provide a valid url'
-        });
-    }
-    const storedUrl = decoder(encodedUrl);
-    if (!storedUrl) {
-      return res
-        .status(404)
-        .json({
-          message: 'Short url not found.'
-        });
-    }
-    return res
-      .status(200)
-      .json({
-        message: 'Success',
-        data: storedUrl
-      });
-  } catch (error) {
-    if (error.code) {
-      return res
-        .status(error.code)
-        .json({
-          message: error.message
-        });
-    }
-    return res
-      .status(500)
-      .json({
-        message: 'Sorry, something on our went wrong.'
-      });
   }
 };
+
+module.exports = presentation;

--- a/presentation/encode.js
+++ b/presentation/encode.js
@@ -1,31 +1,35 @@
-import validator from 'validator';
-import shortener from '../application/encode.js';
+const validator = require('validator');
 
-export default (req, res) => {
-  const {url} = req.body;
-  if (!url) {
+const encodeApp = require('../application/encode.js');
+
+const presentation = {
+  encode(req, res) {
+    const {url} = req.body;
+    if (!url) {
+      return res
+        .status(400)
+        .json({
+          message: 'Should provide a url to encode'
+        });
+    }
+    if (!validator.isURL(url)) {
+      return res
+        .status(400)
+        .json({
+          message: 'Should provide a valid url to encode'
+        });
+    }
+    let protocolIncludedUrl = url;
+    if (!/^https?:\/\//i.test(url)) {
+      protocolIncludedUrl = 'http://' + url;
+    }
+    const shortUrl = encodeApp.encode(protocolIncludedUrl);
     return res
-      .status(400)
+      .status(200)
       .json({
-        message: 'Should provide a url to encode'
+        message: 'Success',
+        data: shortUrl,
       });
   }
-  if (!validator.isURL(url)) {
-    return res
-      .status(400)
-      .json({
-        message: 'Should provide a valid url to encode'
-      });
-  }
-  let protocolIncludedUrl = url;
-  if (!/^https?:\/\//i.test(url)) {
-    protocolIncludedUrl = 'http://' + url;
-  }
-  const shortUrl = shortener(protocolIncludedUrl);
-  return res
-    .status(200)
-    .json({
-      message: 'Success',
-      data: shortUrl,
-    });
 };
+module.exports = presentation;

--- a/presentation/index.js
+++ b/presentation/index.js
@@ -1,10 +1,10 @@
-import express from 'express';
-import helmet from 'helmet';
+const express = require('express');
+const helmet = require('helmet');
 
-import rateLimiter from '../middleware/rateLimiter.js';
+const rateLimiter = require('../middleware/rateLimiter.js');
 
-import decoder from './decode.js';
-import encoder from './encode.js';
+const decodePresentation = require('./decode.js');
+const encodePresentation = require('./encode.js');
 
 const app = express();
 
@@ -12,7 +12,7 @@ app.use(helmet());
 app.use(express.json());
 app.use(rateLimiter);
 
-app.use('/decode', decoder);
-app.use('/encode', encoder);
+app.use('/decode', decodePresentation.decode);
+app.use('/encode', encodePresentation.encode);
 
-export default app;
+module.exports = app;

--- a/presentation/tests/decode.test.js
+++ b/presentation/tests/decode.test.js
@@ -1,7 +1,7 @@
-import db from '../../data-access/datastore.js';
-import app from '../index.js';
+const request = require('supertest');
 
-import request from 'supertest';
+const db = require('../../data-access/datastore.js');
+const app = require('../index.js');
 
 describe('/decode route', () => {
   beforeEach(() => {

--- a/presentation/tests/encode.test.js
+++ b/presentation/tests/encode.test.js
@@ -1,7 +1,7 @@
-import db from '../../data-access/datastore.js';
-import app from '../index.js';
+const request = require('supertest');
 
-import request from 'supertest';
+const app = require('../index.js');
+const db = require('../../data-access/datastore.js');
 
 describe('/encode route', () => {
   beforeEach(() => {


### PR DESCRIPTION
The reason behind this decision was the incompatibility of the test tool `jest` mocking system with new es6 module imports